### PR TITLE
Fixed profile save URL

### DIFF
--- a/src/Controller/Backend.php
+++ b/src/Controller/Backend.php
@@ -69,7 +69,7 @@ class Backend implements ControllerProviderInterface
 
         $app['logger.flash']->success("Extended profile information has been saved.");
 
-        return new RedirectResponse($app['routes']->get('profile')->getPath());
+        return new RedirectResponse($app["request"]->getBaseUrl() . $app['routes']->get('profile')->getPath());
     }
 
     /**


### PR DESCRIPTION
Fixed a problem that prevented the browser redirect correctly after
saving a profile. This issue ocurr if Bolt CMS app is not installed in the host root.
