### PR TITLE
fix runtime error in Bolt 3.2 and above

### DIFF
--- a/templates/field_checkbox.twig
+++ b/templates/field_checkbox.twig
@@ -1,3 +1,5 @@
+{% from '@bolt/_macro/_macro.twig' import attr %}
+
 {#=== OPTIONS ========================================================================================================#}
 
 {% set option = {
@@ -28,7 +30,7 @@
 
     <label class="col-sm-2 col-md-3 col-lg-4 control-label" for="{{ key }}">{{ option.label ? option.label : name | capitalize }}</label>
     <div class="col-sm-10 col-md-9 col-lg-8">
-        <input{{ macro.attr(attr_checkbox) }}>
+        <input{{ attr(attr_checkbox) }}>
     </div>
 
 </fieldset>

--- a/templates/field_select.twig
+++ b/templates/field_select.twig
@@ -1,3 +1,5 @@
+{% from '@bolt/_macro/_macro.twig' import attr %}
+
 {#=== OPTIONS ========================================================================================================#}
 
 {% set option = {
@@ -51,7 +53,7 @@
                     } %}
                 {% endif %}
 
-                <option{{ macro.attr(attr_opt) }}>{{ value }}</option>
+                <option{{ attr(attr_opt) }}>{{ value }}</option>
             {% endfor %}
         </select>
     </div>

--- a/templates/field_select.twig
+++ b/templates/field_select.twig
@@ -37,7 +37,7 @@
 
     <label class="col-sm-2 col-md-3 col-lg-4 control-label">{{ option.label ? option.label : name | capitalize }}</label>
     <div class="col-sm-10 col-md-9 col-lg-8">
-        <select{{ macro.attr(attr_select) }}>
+        <select{{ attr(attr_select) }}>
             {% for value in option.values %}
 
                 {% if value is iterable %}

--- a/templates/field_select.twig
+++ b/templates/field_select.twig
@@ -51,7 +51,7 @@
                     } %}
                 {% endif %}
 
-                <option{{ macro.attr(attr_opt) }}>{{ value }}</option>
+                <option{{ macro.attribute(attr_opt) }}>{{ value }}</option>
             {% endfor %}
         </select>
     </div>

--- a/templates/field_text.twig
+++ b/templates/field_text.twig
@@ -1,3 +1,5 @@
+{% from '@bolt/_macro/_macro.twig' import attr %}
+
 {#=== OPTIONS ========================================================================================================#}
 
 {% set option = {
@@ -31,7 +33,7 @@
 
     <label class="col-sm-2 col-md-3 col-lg-4 control-label">{{ option.label ? option.label : name | capitalize }}</label>
     <div class="col-sm-10 col-md-9 col-lg-8">
-        <input{{ macro.attr(attr_text) }}>
+        <input{{ attr(attr_text) }}>
     </div>
 
 </fieldset>

--- a/templates/field_textarea.twig
+++ b/templates/field_textarea.twig
@@ -1,3 +1,5 @@
+{% from '@bolt/_macro/_macro.twig' import attr %}
+
 {#=== OPTIONS ========================================================================================================#}
 
 {% set option = {
@@ -26,7 +28,7 @@
 
     <label class="col-sm-2 col-md-3 col-lg-4 control-label">{{ option.label ? option.label : name | capitalize }}</label>
     <div class="col-sm-10 col-md-9 col-lg-8">
-        <textarea{{ macro.attr(attr_text) }}>{{ content }}</textarea>
+        <textarea{{ attr(attr_text) }}>{{ content }}</textarea>
     </div>
 
 </fieldset>


### PR DESCRIPTION
Add `{% from '@bolt/_macro/_macro.twig' import attr %}` to the top of each of the four input field templates, then find all instances of `{{ macro.attr(attr_text) }}`, `{{ macro.attr(attr_opt) }}` and `{{ macro.attr(attr_checkbox) }}` and **delete** the `macro.` from the twig function. Leave everything else as it is, and runtime error should be fixed for Bolt 3.2 and above.